### PR TITLE
不可視文字として全角文字が混入していたので削除

### DIFF
--- a/ファイル作成ツール.html
+++ b/ファイル作成ツール.html
@@ -210,7 +210,7 @@ lines.forEach(line => {
 output += "\n";
 
 });
-　
+
   const handle = await dirHandle.getFileHandle(filename, { create: true });
   const writable = await handle.createWritable();
   await writable.write(output);


### PR DESCRIPTION
## 概要
ソース内に混入していた全角スペース（U+3000）を除去（不可視文字のため、可読性低下や将来の不具合要因になり得るため）。

## 変更内容
- 全角スペース（U+3000）を削除

Closes #1