### PR TITLE
idが重複してUIが正しく動いていない問題をidからclassに変更しそれに伴いロジックの変更も行うことで修正(#3)

### DIFF
--- a/ファイル作成ツール.html
+++ b/ファイル作成ツール.html
@@ -157,7 +157,7 @@ items.forEach(item => {
         <input type="checkbox"
                class="subhead-check"
                onchange="toggleSubhead(this)">
-               <span id="shomidashi">小見出しをつける</span>
+               <span class="subhead-label">小見出しをつける</span>
       </label>
 
       <input type="text"
@@ -176,16 +176,27 @@ items.forEach(item => {
 }
 
 function toggleSubhead(checkbox) {
+  // チェックボックスが属するセクション出ないなら処理を終了する
   const section = checkbox.closest(".section");
+  if(!section) return;
+
   const input = section.querySelector(".subhead-input");
+  const label = section.querySelector(".subhead-label");
+  if(!input) return;
 
   if (checkbox.checked) {
     input.style.display = "inline-block";
     input.focus();
-    document.getElementById("shomidashi").style.display="none";
+
+    // 操作しているセクションのラベルだけを消す
+    if(label) label.style.display = "none";
+
   } else {
     input.style.display = "none";
     input.value = ""; // OFF時は小見出し消す
+
+    // 操作しているセクションのラベルだけ戻す
+    if(label) label.style.display = "inline";
   }
 }
 


### PR DESCRIPTION
## 概要
小見出しトグルのラベル切り替えが意図したセクションに作用しない問題を修正
原因は id="shomidashi" の重複と、toggleSubhead() が document 全体の要素を参照していたから

## 変更内容
- id="shomidashi" を class="subhead-label" に変更（id重複解消）
- toggleSubhead() を section 内完結に変更

## 確認方法
- 出力画面で複数セクションのチェックON/OFFを切り替え、必ず該当セクションだけが変化することを確認

Closes #3